### PR TITLE
Fix error on desktop file: no quote around the executable name

### DIFF
--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -56,7 +56,7 @@ modules:
     post-install:
       - ln -sf ../bitwig-studio ${FLATPAK_DEST}/bin/
       - mv /app/share/mime/packages/bitwig-studio.xml /app/share/mime/packages/com.bitwig.BitwigStudio.xml
-      - sed -ri 's@/usr/bin/bitwig-studio@bitwig-studio@' /app/share/applications/bitwig-studio.desktop
+      - sed -ri 's@"/usr/bin/bitwig-studio"@bitwig-studio@' /app/share/applications/bitwig-studio.desktop
       - install -d /app/extensions/Plugins
     sources:
       - type: file


### PR DESCRIPTION
I had forgotten that fix. No quotes around the executable name in the `.desktop`