### PR TITLE
20.08beta runtime + Rename the mimetype icons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Instructions
 
 * Install flatpak and flatpak-builder.
 * flatpak remote-add --if-not-exists fdsdk https://cache.sdk.freedesktop.org/freedesktop-sdk.flatpakrepo
-* flatpak install fdsdk org.freedesktop.Sdk//19.08beta
-* flatpak install fdsdk org.freedesktop.Platform//19.08beta
+* flatpak install fdsdk org.freedesktop.Sdk//20.08beta
+* flatpak install fdsdk org.freedesktop.Platform//20.08beta
 * make run
 
 Known Issues

--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -57,6 +57,10 @@ modules:
       - ln -sf ../bitwig-studio ${FLATPAK_DEST}/bin/
       - mv /app/share/mime/packages/bitwig-studio.xml /app/share/mime/packages/com.bitwig.BitwigStudio.xml
       - sed -ri 's@"/usr/bin/bitwig-studio"@bitwig-studio@' /app/share/applications/bitwig-studio.desktop
+      - cd ${FLATPAK_DEST}/share/icons/hicolor/scalable/mimetypes/;
+        for i in * ; do
+          mv $i ${FLATPAK_ID}.$i;
+        done
       - install -d /app/extensions/Plugins
     sources:
       - type: file

--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: com.bitwig.BitwigStudio
 command: bitwig-studio
-runtime-version: "19.08"
+runtime-version: "20.08beta"
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
 rename-desktop-file: bitwig-studio.desktop
@@ -38,7 +38,7 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: '19.08'
+    version: '20.08'
     add-ld-path: lib
     merge-dirs: lxvst;vst3
     subdirectories: true


### PR DESCRIPTION
Closes #4

Go back to 20.08beta runtime. Closes #1 
This fixes the ALSA problem from #6 
There is currently no plugin available for testing (some issue submitting them because of beta), but I have some locally. 