### PR TITLE
Pipewire support (plus new version)

### DIFF
--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -11,6 +11,10 @@ finish-args:
   - --device=all
   - --nodevice=kvm
 
+  # pipewire
+  - --filesystem=xdg-run/pipewire-0
+  - --socket=system-bus
+
   # Needed to talk with pulseaudio or pipewire
   - --share=ipc
 

--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -68,8 +68,8 @@ modules:
       - install -d /app/extensions/Plugins
     sources:
       - type: file
-        url: https://downloads.bitwig.com/stable/3.2.7/bitwig-studio-3.2.7.deb
-        sha512: c8a13dfcf034bbd7f9e0afa63f3b5a5760ee13c79067f8c48bde5af3dd95879ce008a38fc3c39b79369ea7c41176607027e1bb04226cc86af739d7d33d4e1b97
+        url: https://downloads.bitwig.com/stable/3.2.8/bitwig-studio-3.2.8.deb
+        sha512: 0ae8206cc811c7e0f0826e389396ce0aa13e2d34f9a9e96977bf0b103bb5f368d1842a2dcbefb146467515556e1748e24754eeef1915301ea4ea3b4d9d9eb99b
         only-arches:
           - x86_64
 


### PR DESCRIPTION
I added Pipewire support to use Jack. With Qjackctl on the host (outside of the sandbox), and appears and I get sound when I connect things togethe.

It seems also that I needed a newer version.

Closes #2 